### PR TITLE
Peer ID Fixes and Identity v0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog][keepachangelog] and adheres to [Semant
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+## [0.51.0] - 2025-09-26
+
+### Added
+
 - Added identity/main.go to generate identity and peer id
 - Added encryption module identity.go for reusable identity create, save etc funtions
 
@@ -23,6 +35,7 @@ The format is based on [Keep a Changelog][keepachangelog] and adheres to [Semant
 ### Removed
 
 ### Fixed
+
 
 ## [0.50.1] - 2025-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ The format is based on [Keep a Changelog][keepachangelog] and adheres to [Semant
 
 ### Added
 
+- Added identity/main.go to generate identity and peer id
+- Added encryption module identity.go for reusable identity create, save etc funtions
+
 ### Changed
+
+- Updated make file to support identity/main.go
+- Updated node/node.go on loadOrCreateIdentity to use encryption.identity
+- Updated cli/main.go to remove fallbacks for identity
+- Updated install-debros-network.sh script to use new ./cmd/identity and fixed port order on print
 
 ### Deprecated
 
@@ -16,7 +24,7 @@ The format is based on [Keep a Changelog][keepachangelog] and adheres to [Semant
 
 ### Fixed
 
-## [0.50.0] - 2025-09-23
+## [0.50.1] - 2025-09-23
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ The format is based on [Keep a Changelog][keepachangelog] and adheres to [Semant
 
 ### Fixed
 
+## [0.50.0] - 2025-09-23
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
 - Fixed wrong URL /v1/db to /v1/rqlite
 
 ### Security

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-e2e:
 
 .PHONY: build clean test run-node run-node2 run-node3 run-example deps tidy fmt vet lint clear-ports
 
-VERSION := 0.50.0-beta
+VERSION := 0.50.1-beta
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -X 'main.version=$(VERSION)' -X 'main.commit=$(COMMIT)' -X 'main.date=$(DATE)'

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-e2e:
 
 .PHONY: build clean test run-node run-node2 run-node3 run-example deps tidy fmt vet lint clear-ports
 
-VERSION := 0.50.1-beta
+VERSION := 0.51.0-beta
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -X 'main.version=$(VERSION)' -X 'main.commit=$(COMMIT)' -X 'main.date=$(DATE)'
@@ -30,6 +30,7 @@ LDFLAGS := -X 'main.version=$(VERSION)' -X 'main.commit=$(COMMIT)' -X 'main.date
 build: deps
 	@echo "Building network executables (version=$(VERSION))..."
 	@mkdir -p bin
+	go build -ldflags "$(LDFLAGS)" -o bin/identity ./cmd/identity
 	go build -ldflags "$(LDFLAGS)" -o bin/node ./cmd/node
 	go build -ldflags "$(LDFLAGS)" -o bin/network-cli cmd/cli/main.go
 	# Inject gateway build metadata via pkg path variables

--- a/cmd/identity/main.go
+++ b/cmd/identity/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/DeBrosOfficial/network/pkg/encryption"
+)
+
+func main() {
+	var outputPath string
+	var displayOnly bool
+
+	flag.StringVar(&outputPath, "output", "", "Output path for identity key")
+	flag.BoolVar(&displayOnly, "display-only", false, "Only display identity info, don't save")
+	flag.Parse()
+
+	// Generate identity using shared package
+	info, err := encryption.GenerateIdentity()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to generate identity: %v\n", err)
+		os.Exit(1)
+	}
+
+	// If display only, just show the info
+	if displayOnly {
+		fmt.Printf("Node Identity: %s\n", info.PeerID.String())
+		return
+	}
+
+	// Save to file using shared package
+	if outputPath == "" {
+		fmt.Fprintln(os.Stderr, "Output path is required")
+		os.Exit(1)
+	}
+
+	if err := encryption.SaveIdentity(info, outputPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to save identity: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Generated Node Identity: %s\n", info.PeerID.String())
+	fmt.Printf("Identity saved to: %s\n", outputPath)
+}

--- a/pkg/encryption/identity.go
+++ b/pkg/encryption/identity.go
@@ -1,0 +1,71 @@
+package encryption
+
+import (
+	"crypto/rand"
+	"os"
+	"path/filepath"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type IdentityInfo struct {
+	PrivateKey crypto.PrivKey
+	PublicKey  crypto.PubKey
+	PeerID     peer.ID
+}
+
+func GenerateIdentity() (*IdentityInfo, error) {
+	priv, pub, err := crypto.GenerateKeyPairWithReader(crypto.Ed25519, 2048, rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	peerID, err := peer.IDFromPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IdentityInfo{
+		PrivateKey: priv,
+		PublicKey:  pub,
+		PeerID:     peerID,
+	}, nil
+}
+
+func SaveIdentity(identity *IdentityInfo, path string) error {
+	data, err := crypto.MarshalPrivateKey(identity.PrivateKey)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0600)
+}
+
+func LoadIdentity(path string) (*IdentityInfo, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	priv, err := crypto.UnmarshalPrivateKey(data)
+	if err != nil {
+		return nil, err
+	}
+
+	pub := priv.GetPublic()
+	peerID, err := peer.IDFromPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IdentityInfo{
+		PrivateKey: priv,
+		PublicKey:  pub,
+		PeerID:     peerID,
+	}, nil
+}

--- a/scripts/install-debros-network.sh
+++ b/scripts/install-debros-network.sh
@@ -335,40 +335,8 @@ generate_identity() {
     fi
     log "Generating node identity..."
     cd "$INSTALL_DIR/src"
-    cat > /tmp/generate_identity_custom.go << 'EOF'
-package main
-import (
-    "crypto/rand"
-    "flag"
-    "fmt"
-    "os"
-    "path/filepath"
-    "github.com/libp2p/go-libp2p/core/crypto"
-    "github.com/libp2p/go-libp2p/core/peer"
-)
-func main() {
-    var outputPath string
-    flag.StringVar(&outputPath, "output", "", "Output path for identity key")
-    flag.Parse()
-    if outputPath == "" {
-        fmt.Println("Usage: go run generate_identity_custom.go -output <path>")
-        os.Exit(1)
-    }
-    priv, pub, err := crypto.GenerateKeyPairWithReader(crypto.Ed25519, 2048, rand.Reader)
-    if err != nil { panic(err) }
-    peerID, err := peer.IDFromPublicKey(pub)
-    if err != nil { panic(err) }
-    data, err := crypto.MarshalPrivateKey(priv)
-    if err != nil { panic(err) }
-    if err := os.MkdirAll(filepath.Dir(outputPath), 0700); err != nil { panic(err) }
-    if err := os.WriteFile(outputPath, data, 0600); err != nil { panic(err) }
-    fmt.Printf("Generated Peer ID: %s\n", peerID.String())
-    fmt.Printf("Identity saved to: %s\n", outputPath)
-}
-EOF
     export PATH=$PATH:/usr/local/go/bin
-    sudo -u debros env "PATH=$PATH:/usr/local/go/bin" "GOMOD=$(pwd)" go run /tmp/generate_identity_custom.go -output "$identity_file"
-    rm /tmp/generate_identity_custom.go
+    sudo -u debros env "PATH=$PATH:/usr/local/go/bin" go run ./cmd/identity -output "$identity_file"
     success "Node identity generated"
 }
 
@@ -560,10 +528,10 @@ main() {
     log "${GREEN}Installation Directory:${NOCOLOR} ${CYAN}$INSTALL_DIR${NOCOLOR}"
     log "${GREEN}Configuration:${NOCOLOR} ${CYAN}$INSTALL_DIR/configs/node.yaml${NOCOLOR}"
     log "${GREEN}Logs:${NOCOLOR} ${CYAN}$INSTALL_DIR/logs/node.log${NOCOLOR}"
-    log "${GREEN}Node Port:${NOCOLOR} ${CYAN}$NODE_PORT${NOCOLOR}"
+    log "${GREEN}LibP2P Port:${NOCOLOR} ${CYAN}$NODE_PORT${NOCOLOR}"
     log "${GREEN}RQLite Port:${NOCOLOR} ${CYAN}$RQLITE_PORT${NOCOLOR}"
-    log "${GREEN}Raft Port:${NOCOLOR} ${CYAN}$RAFT_PORT${NOCOLOR}"
     log "${GREEN}Gateway Port:${NOCOLOR} ${CYAN}$GATEWAY_PORT${NOCOLOR}"
+    log "${GREEN}Raft Port:${NOCOLOR} ${CYAN}$RAFT_PORT${NOCOLOR}"
     log "${BLUE}==================================================${NOCOLOR}"
     log "${GREEN}Management Commands:${NOCOLOR}"
     log "${CYAN}  - sudo systemctl status debros-node${NOCOLOR} (Check status)"


### PR DESCRIPTION
### Added

- Added identity/main.go to generate identity and peer id
- Added encryption module identity.go for reusable identity create, save etc funtions

### Changed

- Updated make file to support identity/main.go
- Updated node/node.go on loadOrCreateIdentity to use encryption.identity
- Updated cli/main.go to remove fallbacks for identity
- Updated install-debros-network.sh script to use new ./cmd/identity and fixed port order on print

### Deprecated

### Removed

### Fixed