### PR TITLE
chore: update changelog for v0.51.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog][keepachangelog] and adheres to [Semant
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+## [0.51.6] - 2025-10-24
+
+### Added
+
 - LibP2P added support over NAT
 
 ### Changed


### PR DESCRIPTION
- Added entry for LibP2P NAT support under version 0.51.6
- Created new unreleased section at top of changelog for future updates
- Maintained Keep a Changelog format with standard sections (Added, Changed, Deprecated, etc.)