### PR TITLE
feat: add Go build cache directory to setupDirectories function

### DIFF
--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -680,7 +680,8 @@ func setupDirectories() {
 		"/home/debros/bin",
 		"/home/debros/src",
 		"/home/debros/.debros",
-		"/home/debros/go", // Go module cache directory
+		"/home/debros/go",     // Go module cache directory
+		"/home/debros/.cache", // Go build cache directory
 	}
 
 	for _, dir := range dirs {


### PR DESCRIPTION
- Included a new directory for the Go build cache in the setupDirectories function to enhance the Go environment setup.