### PR TITLE
ci: upgrade go to 1.24, add caching, run unit tests

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Run tests
-        run: pnpm test -- --run
+      - name: Run unit tests
+        run: pnpm vitest run tests/unit
 
       - name: Publish (dry run)
         if: inputs.dry-run == true

--- a/.github/workflows/release-apt.yml
+++ b/.github/workflows/release-apt.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
+          cache-dependency-path: core/go.sum
 
       - name: Get version
         id: version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.24'
-          cache: true
+          cache-dependency-path: core/go.sum
       
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5


### PR DESCRIPTION
- upgrade go to 1.24 in release-apt.yml
- add go.sum dependency caching to release workflows
- update publish-sdk.yml to run vitest unit tests

## Summary

<!-- What does this PR do? Keep it to 1-3 bullet points. -->

## Motivation

<!-- Why is this change needed? Link to an issue if applicable. -->

## Test plan

<!-- How did you verify this works? -->

- [ ] `make test` passes
- [ ] Tested on sandbox/staging environment

## Distributed system impact

<!-- Does this change affect any of the following? If yes, explain. -->

- [ ] Raft quorum / RQLite
- [ ] WireGuard mesh / networking
- [ ] Olric gossip / caching
- [ ] Service startup ordering
- [ ] Rolling upgrade compatibility

## Checklist

- [ ] Tests added for new functionality or bug fix
- [ ] No debug code (`fmt.Println`, `log.Println`) left behind
- [ ] Docs updated (if user-facing behavior changed)
- [ ] Errors wrapped with context (`fmt.Errorf("...: %w", err)`)
