### PR TITLE
ci(publish-sdk): allow same-version on npm bump

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -61,9 +61,13 @@ jobs:
           if [ "${{ github.event_name }}" = "release" ]; then
             VERSION="${{ github.event.release.tag_name }}"
             VERSION="${VERSION#v}"
-            npm version "$VERSION" --no-git-tag-version
+            # --allow-same-version: when /VERSION was already bumped on the
+            # source branch before tagging, package.json may already match
+            # the tag. npm version errors as 'Version not changed' without
+            # this flag.
+            npm version "$VERSION" --no-git-tag-version --allow-same-version
           elif [ -n "${{ inputs.version }}" ]; then
-            npm version ${{ inputs.version }} --no-git-tag-version
+            npm version ${{ inputs.version }} --no-git-tag-version --allow-same-version
           fi
 
       - name: Typecheck


### PR DESCRIPTION
When /VERSION is bumped on the source branch before tagging, the SDK package.json already matches the release tag. Without --allow-same-version, npm version errors as 'Version not changed' and the workflow fails on stable main releases (nightly worked by accident because the bump was done in the previous commit cycle and package.json was a step behind).

## Summary

<!-- What does this PR do? Keep it to 1-3 bullet points. -->

## Motivation

<!-- Why is this change needed? Link to an issue if applicable. -->

## Test plan

<!-- How did you verify this works? -->

- [ ] `make test` passes
- [ ] Tested on sandbox/staging environment

## Distributed system impact

<!-- Does this change affect any of the following? If yes, explain. -->

- [ ] Raft quorum / RQLite
- [ ] WireGuard mesh / networking
- [ ] Olric gossip / caching
- [ ] Service startup ordering
- [ ] Rolling upgrade compatibility

## Checklist

- [ ] Tests added for new functionality or bug fix
- [ ] No debug code (`fmt.Println`, `log.Println`) left behind
- [ ] Docs updated (if user-facing behavior changed)
- [ ] Errors wrapped with context (`fmt.Errorf("...: %w", err)`)
